### PR TITLE
140025210 add failOpen config to oauth

### DIFF
--- a/oauth/index.js
+++ b/oauth/index.js
@@ -46,6 +46,10 @@ module.exports.init = function(config, logger, stats) {
     var request = config.request ? requestLib.defaults(config.request) : requestLib;
     var keys = config.jwk_keys ? JSON.parse(config.jwk_keys) : null;
 
+    let failopenGraceInterval = 0;
+    let failOpenGraceTimeExp = null;
+    let isFailOpen = false;
+
     var middleware = function(req, res, next) {
 
         if ( !req || !res ) return(-1); // need to check bad args 
@@ -73,6 +77,9 @@ module.exports.init = function(config, logger, stats) {
         tokenCache = config.hasOwnProperty('tokenCache') ? config.tokenCache : false;
         //max number of tokens in the cache
         tokenCacheSize = config.hasOwnProperty('tokenCacheSize') ? config.tokenCacheSize : 100;
+
+        failopenGraceInterval = config.hasOwnProperty('failopenGraceInterval') ? config.failopenGraceInterval : 0;
+        isFailOpen = config.hasOwnProperty('failOpen') ? config.failOpen : false;
         //
         //support for enabling oauth or api key only
         var header = false;
@@ -142,9 +149,14 @@ module.exports.init = function(config, logger, stats) {
                         debug('api key cache hit', apiKey);
                         return authorize(req, res, next, logger, stats, value);
                     } else {
-                        cache.remove(apiKey);
-                        debug('api key cache expired', apiKey);
-                        requestApiKeyJWT(req, res, next, config, logger, stats, middleware, apiKey);
+                        if ( isFailOpen === true  && failopenGraceInterval ) {
+                            debug('api key cache expired, using failopen', apiKey);
+                            requestApiKeyJWT(req, res, next, config, logger, stats, middleware, apiKey, value);
+                        } else {
+                            cache.remove(apiKey);
+                            debug('api key cache expired', apiKey);
+                            requestApiKeyJWT(req, res, next, config, logger, stats, middleware, apiKey);
+                        }
                     }
                 } else {
                     debug('api key cache miss', apiKey);
@@ -157,7 +169,7 @@ module.exports.init = function(config, logger, stats) {
 
     }
 
-    function requestApiKeyJWT(req, res, next, config, logger, stats, middleware, apiKey) {
+    function requestApiKeyJWT(req, res, next, config, logger, stats, middleware, apiKey, oldToken) {
 
         if (!config.verify_api_key_url) return sendError(req, res, next, logger, stats, 'invalid_request', 'API Key Verification URL not configured');
 
@@ -196,6 +208,26 @@ module.exports.init = function(config, logger, stats) {
         }
         //debug(api_key_options);
         request(api_key_options, function(err, response, body) {
+            if ( isFailOpen === true &&  oldToken ) {
+                if ( err || parseInt(response.statusCode/100) === 5 ) {
+                    if ( !failOpenGraceTimeExp ) { // start the failopen grace interval if not already started
+                        failOpenGraceTimeExp = Date.now() + failopenGraceInterval*1000; // sec to ms
+                        logger.eventLog({level:'info', req: req, res: res, err:null, component:LOG_TAG_COMP }, "using failOpen and starting failopenGraceInterval");
+                    }
+                    if ( Date.now() < failOpenGraceTimeExp ) {
+                        req['failed-open'] = true; // pass the flag to next plugins
+                        debug('failed-open set to true due to statusCode:',response.statusCode);
+                        logger.eventLog({level:'warn', req: req, res: res, err:null, component:LOG_TAG_COMP }, "failed-open set to true due to statusCode:"+response.statusCode);
+                        return authorize(req, res, next, logger, stats, oldToken); // use old token for failopenGraceInterval if 5XX
+                    } else {
+                        cache.remove(apiKey); // failopen grace interval over, remove cache
+                    }
+                } else {
+                    // api is success now, remove expired token from cache and stop the failopen grace interval
+                    failOpenGraceTimeExp = null;
+                    cache.remove(apiKey);
+                }
+            }
             if (err) {
                 debug('verify apikey gateway timeout');
                 return sendError(req, res, next, logger, stats, 'gateway_timeout', err.message);


### PR DESCRIPTION
add failOpen and failopenGraceInterval configuration to oauth.
If failOpen is true and failopenGraceInterval is set the old token is used in case of 5xx errors in verifyApiKey call.
To use this feature set in oauth config as:

oauth:
  failopenGraceInterval: 5 (in seconds, old token will be used for this time duration)
  failOpen: true

This feature is applicable only if oauth.cacheKey is set to true.