### PR TITLE
133162200 Make unauthorized tokens available to Analytics

### DIFF
--- a/apikeys/index.js
+++ b/apikeys/index.js
@@ -176,6 +176,7 @@ module.exports.init = function(config, logger, stats) {
         var decodedToken = {}
         try {
             decodedToken = JWS.parse(oauthtoken);
+            req.token = decodedToken.payloadObj;
         } catch(e) {
             return sendError(req, res, next, logger, stats, "access_denied", 'apikeys plugin failed to parse token in verify');
         }
@@ -224,7 +225,6 @@ module.exports.init = function(config, logger, stats) {
 
     function authorize(req, res, next, logger, stats, decodedToken, apiKey) {
         if (checkIfAuthorized(config, req, res, decodedToken, productOnly, logger, LOG_TAG_COMP)) {
-            req.token = decodedToken;
 
             var authClaims = _.omit(decodedToken, PRIVATE_JWT_VALUES);
             req.headers["x-authorization-claims"] = new Buffer(JSON.stringify(authClaims)).toString("base64");

--- a/lib/basicAuth.js
+++ b/lib/basicAuth.js
@@ -285,7 +285,8 @@ class BasicAuthorizerPlugin {
         var decodedToken = null;
         //
         try {
-			decodedToken = JWS.parse(oauthtoken);
+            decodedToken = JWS.parse(oauthtoken);
+            req.token = decodedToken.payloadObj;
 		} catch (err) {
             if ( this.allowInvalidAuthorization ) {
                 // TODO: convert to logger.eventLog
@@ -354,7 +355,6 @@ class BasicAuthorizerPlugin {
     authorize(req, res, decodedToken) {
         //
         if ( this.checkIfAuthorized(this.config, req.reqUrl.path, res.proxy, decodedToken) ) {
-            req.token = decodedToken;
             //
             var authClaims = _objectWithoutProperties(decodedToken, PRIVATE_JWT_VALUES);
             req.headers['x-authorization-claims'] = new Buffer(JSON.stringify(authClaims)).toString('base64');

--- a/oauth/index.js
+++ b/oauth/index.js
@@ -263,6 +263,7 @@ module.exports.init = function(config, logger, stats) {
         //
         try {
             decodedToken = JWS.parse(oauthtoken);
+            req.token = decodedToken.payloadObj;
         } catch(e) {
             // 'invalid_token'
             return sendError(req, res, next, logger, stats, 'invalid_token','token could not be parsed');
@@ -344,7 +345,6 @@ module.exports.init = function(config, logger, stats) {
 
     function authorize(req, res, next, logger, stats, decodedToken, apiKey) {
         if (checkIfAuthorized(config, req, res, decodedToken, productOnly, logger, LOG_TAG_COMP)) {
-            req.token = decodedToken;
 
             var authClaims = _.omit(decodedToken, PRIVATE_JWT_VALUES);
             req.headers['x-authorization-claims'] = new Buffer(JSON.stringify(authClaims)).toString('base64');

--- a/oauthv2/index.js
+++ b/oauthv2/index.js
@@ -89,7 +89,8 @@ module.exports.init = function(config, logger, stats) {
         var oauthtoken = token && token.token ? token.token : token;
 		var decodedToken;
 		try {
-			decodedToken = JWS.parse(oauthtoken);
+            decodedToken = JWS.parse(oauthtoken);
+            req.token = decodedToken.payloadObj;
 		} catch (err) {
             if (config.allowInvalidAuthorization) {
                 logger.eventLog({level:'warn', req: req, res: res, err: err, component:LOG_TAG_COMP }, 'ignoring err');
@@ -175,7 +176,6 @@ module.exports.init = function(config, logger, stats) {
 
     function authorize(req, res, next, logger, stats, decodedToken) {
         if (checkIfAuthorized(config, req, res, decodedToken, productOnly, logger, LOG_TAG_COMP)) {
-            req.token = decodedToken;
             var authClaims = _.omit(decodedToken, PRIVATE_JWT_VALUES);
             req.headers['x-authorization-claims'] = new Buffer(JSON.stringify(authClaims)).toString('base64');
             next();


### PR DESCRIPTION
Set the decoded token on request object before checking for authorisation because analytics needs the developer info.